### PR TITLE
Add settings with loaded/disabled plugins listing

### DIFF
--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -14,6 +14,7 @@ class Bot(object):
         self.updater = Updater(token=os.getenv('TELEGRAM_BOT_TOKEN'))
         self.dispatcher.add_handler(CommandHandler('start', self.start))
         self.dispatcher.add_handler(CommandHandler('help', self.help))
+        self.dispatcher.add_handler(CommandHandler('settings', self.settings))
         self.plugins = get_plugins(self.dispatcher)
 
     @property
@@ -60,6 +61,16 @@ class Bot(object):
             msg = '{}\n{}'.format(msg, handler_msg)
         return msg.replace('_', '\_')
 
+    @property
+    def loaded_plugins(self):
+        return ','.join([name.split('.')[-1] for name in self.plugins.keys()])
+
+    @property
+    def settings_message(self):
+        msg = 'Here is a list of my settings:'
+        msg = '{}\n- `loaded_plugins`: {}'.format(msg, self.loaded_plugins)
+        return msg
+
     def start(self, bot, update):
         '''
         Greet and list of features I am providing.
@@ -83,6 +94,18 @@ class Bot(object):
         bot.send_message(
             chat_id=update.message.chat_id,
             text=self.help_message,
+            parse_mode=ParseMode.MARKDOWN,
+        )
+
+    def settings(self, bot, update):
+        '''
+        List my settings.
+
+        These settings can include loaded plugins' settings.
+        '''
+        bot.send_message(
+            chat_id=update.message.chat_id,
+            text=self.settings_message,
             parse_mode=ParseMode.MARKDOWN,
         )
 

--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -16,6 +16,10 @@ class Bot(object):
         self.plugins = get_plugins(self.dispatcher)
 
     @property
+    def name(self):
+        return self.bot.get_me()["first_name"]
+
+    @property
     def username(self):
         return self.bot.get_me()["username"]
 
@@ -27,10 +31,17 @@ class Bot(object):
     def dispatcher(self):
         return self.updater.dispatcher
 
+    @property
+    def start_message(self):
+        msg = "I am {} (@{})".format(self.name, self.username)
+        for plugin in self.plugins:
+            msg = "{}\n{}".format(msg, self.plugins[plugin].feature_desc)
+        return msg
+
     def start(self, bot, update):
         bot.send_message(
             chat_id=update.message.chat_id,
-            text="I'm {}, please talk to me".format(self.username),
+            text=self.start_message,
         )
 
     def help(self, bot, update):
@@ -40,5 +51,5 @@ class Bot(object):
         )
 
     def run(self):
-        logger.info("I am {}".format(self.username))
+        logger.info("I am {} (@{})".format(self.name, self.username))
         self.updater.start_polling()

--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -62,13 +62,22 @@ class Bot(object):
         return msg.replace('_', '\_')
 
     @property
+    def disabled_plugins(self):
+        return ','.join(
+            [name for name in self.plugins if self.plugins[name] is None]
+        )
+
+    @property
     def loaded_plugins(self):
-        return ','.join([name.split('.')[-1] for name in self.plugins.keys()])
+        return ','.join(
+            [name for name in self.plugins if self.plugins[name]]
+        )
 
     @property
     def settings_message(self):
         msg = 'Here is a list of my settings:'
         msg = '{}\n- `loaded_plugins`: {}'.format(msg, self.loaded_plugins)
+        msg = '{}\n- `disabled_plugins`: {}'.format(msg, self.disabled_plugins)
         return msg
 
     def start(self, bot, update):

--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -3,6 +3,8 @@ import logging
 
 from telegram.ext import Updater, CommandHandler
 
+from reventlov.plugins import get_plugins
+
 logger = logging.getLogger(__name__)
 
 
@@ -11,6 +13,7 @@ class Bot(object):
         self.updater = Updater(token=os.getenv("TELEGRAM_BOT_TOKEN"))
         self.dispatcher.add_handler(CommandHandler("start", self.start))
         self.dispatcher.add_handler(CommandHandler("help", self.help))
+        self.plugins = get_plugins(self.dispatcher)
 
     @property
     def username(self):

--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -1,6 +1,7 @@
 import os
 import logging
 
+from telegram import ParseMode
 from telegram.ext import Updater, CommandHandler
 
 from reventlov.plugins import get_plugins
@@ -10,18 +11,18 @@ logger = logging.getLogger(__name__)
 
 class Bot(object):
     def __init__(self):
-        self.updater = Updater(token=os.getenv("TELEGRAM_BOT_TOKEN"))
-        self.dispatcher.add_handler(CommandHandler("start", self.start))
-        self.dispatcher.add_handler(CommandHandler("help", self.help))
+        self.updater = Updater(token=os.getenv('TELEGRAM_BOT_TOKEN'))
+        self.dispatcher.add_handler(CommandHandler('start', self.start))
+        self.dispatcher.add_handler(CommandHandler('help', self.help))
         self.plugins = get_plugins(self.dispatcher)
 
     @property
     def name(self):
-        return self.bot.get_me()["first_name"]
+        return self.bot.get_me()['first_name']
 
     @property
     def username(self):
-        return self.bot.get_me()["username"]
+        return self.bot.get_me()['username']
 
     @property
     def bot(self):
@@ -33,23 +34,58 @@ class Bot(object):
 
     @property
     def start_message(self):
-        msg = "I am {} (@{})".format(self.name, self.username)
+        msg = 'I am {} (@{})'.format(self.name, self.username)
+        features_msg = ''
         for plugin in self.plugins:
-            msg = "{}\n{}".format(msg, self.plugins[plugin].feature_desc)
+            features_msg = '{}\n- {}'.format(
+                features_msg,
+                self.plugins[plugin].feature_desc,
+            )
+        if len(features_msg) > 0:
+            msg = '{}{}'.format(msg, features_msg)
         return msg
 
+    @property
+    def help_message(self):
+        msg = 'I am offering the following:'
+        for handler in self.dispatcher.handlers[0]:
+            if handler.__class__ == CommandHandler:
+                help_msg = handler.callback.__doc__ or '\nUndefined command'
+                handler_msg = '- /{}: {}'.format(
+                    handler.command[0],
+                    help_msg.splitlines()[1].strip()
+                )
+            else:
+                handler_msg = 'Undefined message'
+            msg = '{}\n{}'.format(msg, handler_msg)
+        return msg.replace('_', '\_')
+
     def start(self, bot, update):
+        '''
+        Greet and list of features I am providing.
+
+        The list of features are including the feature descriptions of all
+        the plugins loaded.
+        '''
         bot.send_message(
             chat_id=update.message.chat_id,
             text=self.start_message,
+            parse_mode=ParseMode.MARKDOWN,
         )
 
     def help(self, bot, update):
+        '''
+        Help about my features.
+
+        The list might include many different kinds of help text from all the
+        different plugins loaded.
+        '''
         bot.send_message(
             chat_id=update.message.chat_id,
-            text="This is my help",
+            text=self.help_message,
+            parse_mode=ParseMode.MARKDOWN,
         )
 
     def run(self):
-        logger.info("I am {} (@{})".format(self.name, self.username))
+        logger.info('I am {} (@{})'.format(self.name, self.username))
         self.updater.start_polling()

--- a/reventlov/plugins/__init__.py
+++ b/reventlov/plugins/__init__.py
@@ -1,0 +1,30 @@
+import os
+import logging
+import importlib
+import pkgutil
+
+logger = logging.getLogger(__name__)
+
+
+def iter_namespaces():
+    return pkgutil.iter_modules(
+        [os.path.dirname(__file__)],
+        'reventlov.plugins.',
+    )
+
+
+plugins = {
+    name: importlib.import_module(name)
+    for finder, name, ispkg
+    in iter_namespaces()
+}
+
+
+def get_plugins(dispatcher):
+    plugin_dict = {}
+    for name in plugins:
+        if 'Bot' in dir(plugins[name]):
+            plugin_dict[name] = plugins[name].Bot(dispatcher)
+        else:
+            logger.warn("Plugin {} does not provide Bot class".format(name))
+    return plugin_dict

--- a/reventlov/plugins/pomodoro/__init__.py
+++ b/reventlov/plugins/pomodoro/__init__.py
@@ -1,0 +1,54 @@
+import logging
+
+from telegram.ext import CommandHandler
+
+logger = logging.getLogger(__name__)
+
+class Bot(object):
+    def __init__(self, dispatcher):
+        dispatcher.add_handler(CommandHandler(
+            'set',
+            self.set_timer,
+            pass_args=True,
+            pass_job_queue=True,
+            pass_chat_data=True,
+        ))
+        dispatcher.add_handler(CommandHandler(
+            'unset',
+            self.unset_timer,
+            pass_chat_data=True,
+        ))
+        self.version = '0.0.1'
+        logger.info("Pomodoro plugin v{} loaded".format(self.version))
+
+    def alarm(self, bot, job):
+        bot.send_message(job.context['chat_id'], text=job.context['text'])
+
+    def set_timer(self, bot, update, args, job_queue, chat_data):
+        chat_id = update.message.chat_id
+        try:
+            due = int(args[0])
+            if due < 0:
+                update.message.reply_text(
+                    'Sorry we can not go back to future!'
+                )
+                return
+            job = job_queue.run_once(self.alarm, due, context={
+                'chat_id': chat_id,
+                'text': ' '.join(args[1:]) or 'Beep!'
+            })
+            chat_data['job'] = job
+            update.message.reply_text('Timer successfully set!')
+        except (IndexError, ValueError):
+            update.message.reply_text('Usage: /set <seconds> <message...>')
+
+    def unset_timer(self, bot, update, chat_data):
+        if 'job' not in chat_data:
+            update.message.reply_text('You have no active timer')
+            return
+
+        job = chat_data['job']
+        job.schedule_removal()
+        del chat_data['job']
+
+        update.message.reply_text('Timer successfully unset!')

--- a/reventlov/plugins/pomodoro/__init__.py
+++ b/reventlov/plugins/pomodoro/__init__.py
@@ -4,6 +4,7 @@ from telegram.ext import CommandHandler
 
 logger = logging.getLogger(__name__)
 
+
 class Bot(object):
     def __init__(self, dispatcher):
         dispatcher.add_handler(CommandHandler(

--- a/reventlov/plugins/pomodoro/__init__.py
+++ b/reventlov/plugins/pomodoro/__init__.py
@@ -29,6 +29,9 @@ class Bot(object):
         bot.send_message(job.context['chat_id'], text=job.context['text'])
 
     def set_timer(self, bot, update, args, job_queue, chat_data):
+        '''
+        `seconds [message...]` Set alarm to fire in `seconds`.
+        '''
         chat_id = update.message.chat_id
         try:
             due = int(args[0])
@@ -44,9 +47,12 @@ class Bot(object):
             chat_data['job'] = job
             update.message.reply_text('Timer successfully set!')
         except (IndexError, ValueError):
-            update.message.reply_text('Usage: /set <seconds> <message...>')
+            update.message.reply_markdown('Usage: `/set seconds [message...]`')
 
     def unset_timer(self, bot, update, chat_data):
+        '''
+        Unset last alarm set.
+        '''
         if 'job' not in chat_data:
             update.message.reply_text('You have no active timer')
             return

--- a/reventlov/plugins/pomodoro/__init__.py
+++ b/reventlov/plugins/pomodoro/__init__.py
@@ -21,6 +21,10 @@ class Bot(object):
         self.version = '0.0.1'
         logger.info("Pomodoro plugin v{} loaded".format(self.version))
 
+    @property
+    def feature_desc(self):
+        return "I can manage pomodoro alarms for you"
+
     def alarm(self, bot, job):
         bot.send_message(job.context['chat_id'], text=job.context['text'])
 


### PR DESCRIPTION
This change adds the `/settings` command providing lists of loaded and disabled plugins.
The plugins to be disabled are providen by a comma-separated list in the `REVENTLOV_DISABLED_PLUGINS` environment variable.

It is recommended to review in a per commit basis.