### PR TITLE
Add settings management with loaded/disabled plugins listing

### DIFF
--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -62,13 +62,22 @@ class Bot(object):
         return msg.replace('_', '\_')
 
     @property
-    def loaded_plugins(self):
-        return ','.join([name.split('.')[-1] for name in self.plugins.keys()])
+    def disabled_plugins(self):
+        return ', '.join(sorted(
+            [name for name in self.plugins if self.plugins[name] is None]
+        ))
+
+    @property
+    def enabled_plugins(self):
+        return ', '.join(sorted(
+            [name for name in self.plugins if self.plugins[name]]
+        ))
 
     @property
     def settings_message(self):
         msg = 'Here is a list of my settings:'
-        msg = '{}\n- `loaded_plugins`: {}'.format(msg, self.loaded_plugins)
+        msg = '{}\n- `enabled_plugins`: {}'.format(msg, self.enabled_plugins)
+        msg = '{}\n- `disabled_plugins`: {}'.format(msg, self.disabled_plugins)
         return msg
 
     def start(self, bot, update):

--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -14,6 +14,7 @@ class Bot(object):
         self.updater = Updater(token=os.getenv('TELEGRAM_BOT_TOKEN'))
         self.dispatcher.add_handler(CommandHandler('start', self.start))
         self.dispatcher.add_handler(CommandHandler('help', self.help))
+        self.dispatcher.add_handler(CommandHandler('settings', self.settings))
         self.plugins = get_plugins(self.dispatcher)
 
     @property
@@ -60,6 +61,16 @@ class Bot(object):
             msg = '{}\n{}'.format(msg, handler_msg)
         return msg.replace('_', '\_')
 
+    @property
+    def loaded_plugins(self):
+        return ','.join([name.split('.')[-1] for name in self.plugins.keys()])
+
+    @property
+    def settings_message(self):
+        msg = 'Here is a list of my settings:'
+        msg = '{}\n- `loaded_plugins`: {}'.format(msg, self.loaded_plugins)
+        return msg
+
     def start(self, bot, update):
         '''
         Greet and list of features I am providing.
@@ -83,6 +94,18 @@ class Bot(object):
         bot.send_message(
             chat_id=update.message.chat_id,
             text=self.help_message,
+            parse_mode=ParseMode.MARKDOWN,
+        )
+
+    def settings(self, bot, update):
+        '''
+        List my settings.
+
+        These settings can include loaded plugins' settings.
+        '''
+        bot.send_message(
+            chat_id=update.message.chat_id,
+            text=self.settings_message,
             parse_mode=ParseMode.MARKDOWN,
         )
 

--- a/reventlov/bot.py
+++ b/reventlov/bot.py
@@ -35,15 +35,13 @@ class Bot(object):
 
     @property
     def start_message(self):
-        msg = 'I am {} (@{})'.format(self.name, self.username)
+        msg = f'I am {self.name} (@{self.username})'
         features_msg = ''
         for plugin in self.plugins:
-            features_msg = '{}\n- {}'.format(
-                features_msg,
-                self.plugins[plugin].feature_desc,
-            )
+            feature_desc = self.plugins[plugin].feature_desc
+            features_msg = f'{features_msg}\n- {feature_desc}'
         if len(features_msg) > 0:
-            msg = '{}{}'.format(msg, features_msg)
+            msg = f'{msg}{features_msg}'
         return msg
 
     @property
@@ -52,14 +50,13 @@ class Bot(object):
         for handler in self.dispatcher.handlers[0]:
             if handler.__class__ == CommandHandler:
                 help_msg = handler.callback.__doc__ or '\nUndefined command'
-                handler_msg = '- /{}: {}'.format(
-                    handler.command[0],
-                    help_msg.splitlines()[1].strip()
-                )
+                help_header = help_msg.splitlines()[1].strip()
+                cmd = handler.command[0]
+                handler_msg = f'- /{cmd}: {help_header}'
             else:
                 handler_msg = 'Undefined message'
-            msg = '{}\n{}'.format(msg, handler_msg)
-        return msg.replace('_', '\_')
+            msg = f'{msg}\n{handler_msg}'.replace('_', '\_')
+        return msg
 
     @property
     def disabled_plugins(self):
@@ -76,8 +73,8 @@ class Bot(object):
     @property
     def settings_message(self):
         msg = 'Here is a list of my settings:'
-        msg = '{}\n- `enabled_plugins`: {}'.format(msg, self.enabled_plugins)
-        msg = '{}\n- `disabled_plugins`: {}'.format(msg, self.disabled_plugins)
+        msg = f'{msg}\n- `enabled_plugins`: {self.enabled_plugins}'
+        msg = f'{msg}\n- `disabled_plugins`: {self.disabled_plugins}'
         return msg
 
     def start(self, bot, update):
@@ -119,5 +116,5 @@ class Bot(object):
         )
 
     def run(self):
-        logger.info('I am {} (@{})'.format(self.name, self.username))
+        logger.info(f'I am {self.name} (@{self.username})')
         self.updater.start_polling()

--- a/reventlov/plugins/__init__.py
+++ b/reventlov/plugins/__init__.py
@@ -34,6 +34,6 @@ def get_plugins(dispatcher):
                 plugins[name] = plugins[name].Bot(dispatcher)
             else:
                 logger.warn(
-                    "Plugin {} does not provide Bot class".format(name)
+                    f'Plugin {name} does not provide Bot class'
                 )
     return plugins

--- a/reventlov/plugins/pomodoro/__init__.py
+++ b/reventlov/plugins/pomodoro/__init__.py
@@ -20,11 +20,11 @@ class Bot(object):
             pass_chat_data=True,
         ))
         self.version = '0.0.1'
-        logger.info("Pomodoro plugin v{} loaded".format(self.version))
+        logger.info(f'Pomodoro plugin v{self.version} loaded')
 
     @property
     def feature_desc(self):
-        return "I can manage pomodoro alarms for you"
+        return 'I can manage pomodoro alarms for you'
 
     def alarm(self, bot, job):
         bot.send_message(job.context['chat_id'], text=job.context['text'])


### PR DESCRIPTION
This change adds the `/settings` command providing lists of loaded and disabled plugins.
The plugins to be disabled are providen by a comma-separated list in the `REVENTLOV_DISABLED_PLUGINS` environment variable.

It is recommended to review in a per commit basis.