### PR TITLE
Add BotPlugin class

### DIFF
--- a/reventlov/bot_plugin.py
+++ b/reventlov/bot_plugin.py
@@ -1,0 +1,19 @@
+from telegram.ext import CommandHandler
+
+
+class BotPlugin(object):
+    @property
+    def commands(self):
+        return [
+            handler
+            for handler in self.handlers
+            if handler.__class__ == CommandHandler
+        ]
+
+    def add_handlers(self, dispatcher):
+        for handler in self.handlers:
+            dispatcher.add_handler(handler)
+
+    def remove_handlers(self, dispatcher):
+        for handler in self.handlers:
+            dispatcher.remove_handler(handler)

--- a/reventlov/plugins/pomodoro/__init__.py
+++ b/reventlov/plugins/pomodoro/__init__.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 logger.info(f'Pomodoro module v{version} loaded')
 
 
-class Bot(BotPlugin):
+class PomodoroPlugin(BotPlugin):
     '''
     I can manage pomodoro alarms for you
     '''

--- a/reventlov/plugins/pomodoro/__init__.py
+++ b/reventlov/plugins/pomodoro/__init__.py
@@ -2,12 +2,14 @@ import logging
 
 from telegram.ext import CommandHandler
 
+from reventlov.bot_plugin import BotPlugin
+
 version = '0.0.1'
 logger = logging.getLogger(__name__)
 logger.info(f'Pomodoro module v{version} loaded')
 
 
-class Bot(object):
+class Bot(BotPlugin):
     '''
     I can manage pomodoro alarms for you
     '''
@@ -28,22 +30,6 @@ class Bot(object):
         ]
         self.add_handlers(dispatcher)
         logger.info(f'Pomodoro plugin v{version} enabled')
-
-    @property
-    def commands(self):
-        return [
-            handler
-            for handler in self.handlers
-            if handler.__class__ == CommandHandler
-        ]
-
-    def add_handlers(self, dispatcher):
-        for handler in self.handlers:
-            dispatcher.add_handler(handler)
-
-    def remove_handlers(self, dispatcher):
-        for handler in self.handlers:
-            dispatcher.remove_handler(handler)
 
     def alarm(self, bot, job):
         bot.send_message(job.context['chat_id'], text=job.context['text'])


### PR DESCRIPTION
This class must be used to implement bot plugins, subclassing it.
It provides of common code for any bot plugin.
It is also used to identify which is the class implementing the bot plugin in the module.