### PR TITLE
Add testing for name and username

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -84,6 +84,11 @@ bot_test_cases = {
 class Updater(object):
     def __init__(self, *args, **kwargs):
         self.dispatcher = Dispatcher()
+        self.bot = BotInterface()
+        self.polling = False
+
+    def start_polling(self):
+        self.polling = not self.polling
 
 
 class Dispatcher(object):
@@ -94,21 +99,52 @@ class Dispatcher(object):
         self.registered_handlers.append(handler.command[0])
 
 
+class BotInterface(object):
+    def get_me(self):
+        return {
+            'first_name': 'R. Giskard Reventlov',
+            'username': 'reventlovbot',
+        }
+
+
+class Logger(object):
+    def __init__(self):
+        self.__info = []
+
+    def info(self, message):
+        self.__info.append(message)
+
+    @property
+    def messages(self):
+        messages = []
+        messages.extend(self.__info)
+        return messages
+
+
 @pytest.mark.parametrize(
     'environ, present_plugins, expected',
     bot_test_cases['tests'],
     ids=bot_test_cases['ids'],
 )
-def test_bot_creation(mocker, environ, present_plugins, expected):
+def test_bot(mocker, environ, present_plugins, expected):
     mocker.patch.dict(os.environ, environ)
-    mocker.patch('reventlov.bot.Updater', new=lambda *a, **kw: Updater(a, kw))
+    mocker.patch(
+        'reventlov.bot.Updater',
+        new=lambda *a, **kw: Updater(a, kw),
+    )
     bot_plugins = mocker.patch(
         'reventlov.bot.BotPlugins',
         spec=True,
         enabled_plugins=present_plugins,
     )
+    logger = Logger()
+    mocker.patch(
+        'reventlov.bot.logger',
+        new=logger,
+    )
 
     bot = Bot()
+    bot.run()
 
     assert bot.admins == expected['admins']
     commands = [handler for handler in bot.dispatcher.registered_handlers]
@@ -117,3 +153,5 @@ def test_bot_creation(mocker, environ, present_plugins, expected):
         assert command in expected['commands']
     bot_plugins.assert_called_once_with(bot.dispatcher)
     assert bot.enabled_plugins == expected['enabled_plugins']
+    assert bot.updater.polling
+    assert 'I am R. Giskard Reventlov (@reventlovbot)' in logger.messages


### PR DESCRIPTION
This adds some more mocks and tests the logged message with the bot name and username are correct.

Refs #19